### PR TITLE
removal of twistcli executable and additional directions to download …

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Twistlock Subscription - https://www.twistlock.com/
 
 ### Documentation:
 
+You need to download Twistlock packages from release page at Twistlock's website.
+
+You will need to extract the CLI `twistcli` from the tar.gz and place into this repositories' packages folder.
+
 Twistlock CLI: https://twistlock.desk.com/customer/en/portal/articles/2879128-scan-images-with-twistcli
 
 ## Local Usage


### PR DESCRIPTION
…and copy cli to directory to create personal Docker image

This can no longer be built from our pipeline or pushed publicly.

The repository must be cloned by Twistlock users and they add the Twistlock CLI on their own and create a private Docker image for their use.